### PR TITLE
Bridge contract changes

### DIFF
--- a/contracts/ETNBridge.sol
+++ b/contracts/ETNBridge.sol
@@ -65,6 +65,13 @@ contract ETNBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentr
     function crosschainTransfer(address payable _address, string memory _legacyETNAddress, uint256 _amount, string memory _txHash, bool _isOracle) public onlyOwner nonReentrant whenNotPaused {
         // Address verification
         require(_address != address(0), "Invalid address");
+
+        uint32 size;
+        assembly {
+            size := extcodesize(_address)
+        }
+        require(size == 0, "Cannot send to contract address");  // Prevent sending to contract addresses
+
         bytes memory tempLegacyETNBytes = bytes(_legacyETNAddress);
         require(tempLegacyETNBytes.length == 98, "Invalid legacy ETN address");
         // Amount verification

--- a/contracts/ETNBridge.sol
+++ b/contracts/ETNBridge.sol
@@ -63,7 +63,6 @@ contract ETNBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentr
 
     function crosschainTransfer(address payable _address, string memory _legacyETNAddress, uint256 _amount, string memory _txHash, bool _isOracle) public onlyOwner nonReentrant whenNotPaused {
         // Address verification
-        require(_address == address(_address), "Invalid address format");
         require(_address != address(0), "Invalid address");
         bytes memory tempLegacyETNBytes = bytes(_legacyETNAddress);
         require(tempLegacyETNBytes.length == 98, "Invalid legacy ETN address");
@@ -74,10 +73,6 @@ contract ETNBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentr
         bytes memory tempTXHashBytes = bytes(_txHash);
         require(tempTXHashBytes.length == 64, "Invalid transaction hash");
         require(txMap[_txHash] == 0, "Duplicate crosschain transaction");
-
-        // Store EOA and Contract old balance
-        uint256 addressOldBalance = _address.balance;
-        uint256 contractOldBalance = address(this).balance;
 
         // Check the LegacyAddress <-> Address map, a legacy ETN address should be mapped to the same SC address
         if(crosschainLegacyETNtoAddress[_legacyETNAddress] != address(0)) {
@@ -130,8 +125,6 @@ contract ETNBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentr
 
         // Transfer ETN from contract to EOA
         _address.transfer(_amount);
-        require(_address.balance == addressOldBalance + _amount, "Invalid ETN transfer: recipient balance not updated");
-        require(address(this).balance == contractOldBalance - _amount, "Invalid ETN transfer: sender balance not updated");
 
         // Log event
         emit CrossChainTransfer(_legacyETNAddress, _legacyETNAddress, _address, _amount);

--- a/contracts/ETNBridge.sol
+++ b/contracts/ETNBridge.sol
@@ -37,7 +37,7 @@ contract ETNBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, Reentr
 
     // fallback() and receive() definition. This allows ETN to be sent to this contract address.
     fallback() external payable { require(msg.data.length == 0, ""); }
-    receive() external payable { emit DepositReceived(msg.sender, msg.value); }
+    receive() external payable onlyOwner { emit DepositReceived(msg.sender, msg.value); }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/contracts/ETNBridge.sol
+++ b/contracts/ETNBridge.sol
@@ -1,6 +1,6 @@
 // contracts/ETNBridge.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.16;
+pragma solidity ^0.8.20;
 
 // Import from the OpenZeppelin Contracts library
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity 0.8.20;
 
 contract Migrations {
   address public owner = msg.sender;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -91,7 +91,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.16",      // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.20",      // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
- Remove some redundant checks (address check and reentrance code)
- Change the sc address to []legacy address map to a nested mapping so we have constant time lookup when checking to see if a legacy address is already present. This avoids the alternative for-loop way of checking and negates a situation where an attacker fills the mapping with many legacy addresses and performs a gas attack.
- Refactor code for placing new legacy addresses in a map.
- Prevent crosschainTransfer sending to contracts to negate gas attack where the stipend is intentionally wasted.
- Change receive() to be onlyOwner to prevent unwanted deposits.
- Bump Solidity Version to 8.20
